### PR TITLE
Gennady's Code Challenge

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -11,7 +11,8 @@
             "elm/html": "1.0.0",
             "elm/http": "2.0.0",
             "elm/json": "1.1.2",
-            "elm/random": "1.0.0"
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0"
         },
         "indirect": {
             "elm/bytes": "1.0.7",

--- a/src/Filter.elm
+++ b/src/Filter.elm
@@ -45,7 +45,8 @@ filterText model text =
 
 -- UPDATE
 type Msg = ToggleEnabled Bool | AddFilterPair
-    | ToggleShowList | SetFrom String | SetTo String | RemoveFilterPair (String, String)
+    | ToggleShowList | SetFrom String 
+    | SetTo String | RemoveFilterPair (String, String)
 
 update : Msg -> Model -> (Model, Cmd Msg)
 update msg model =

--- a/src/Filter.elm
+++ b/src/Filter.elm
@@ -1,0 +1,72 @@
+module Filter exposing (..)
+
+import Html exposing (Html, button, div, img, text, input, label)
+import Html.Attributes exposing (type_, checked, value, name, for, id)
+import Html.Events exposing (onInput, onCheck, onClick)
+
+-- MODEL
+type alias Model = 
+    { on: Bool
+    , showList: Bool
+    , filterPairs: List (String, String)
+    }
+
+init =
+    { on = False, showList = False, filterPairs = [("What", "WHAT!!!"), ("Why", "WHY?!?!")] }
+
+
+filterText : Model -> String -> String
+filterText model text =
+    if model.on then
+        let 
+            doReplace toReplace (from, to) =
+                String.replace from to toReplace
+            doFilterText toFilter pairs =
+                let 
+                    nextPair = List.head pairs
+                in
+                    case nextPair of
+                        Nothing ->
+                            toFilter
+                        Just pair ->
+                            doFilterText (doReplace toFilter pair) (List.drop 1 pairs)
+        in
+            doFilterText text model.filterPairs
+    else
+        text
+
+-- UPDATE
+type Msg = ToggleEnabled Bool | AddFilterPair (String, String)
+    | ToggleShowList
+
+update : Msg -> Model -> (Model, Cmd Msg)
+update msg model =
+    case msg of
+        ToggleShowList -> 
+            ({model | showList = not model.showList}, Cmd.none)
+        ToggleEnabled checked ->
+            ({model | on = checked}, Cmd.none)
+        AddFilterPair pair ->
+            (model, Cmd.none)
+        
+
+-- VIEW
+getView : Model -> Html Msg
+getView model =
+    div [] [
+        label [for "filter-enabled"] [text "Filter Enabled"]
+        , input [type_ "checkbox", id "filter-enabled", onCheck ToggleEnabled][]
+        ,if model.showList then
+            div [] [
+                button [onClick ToggleShowList] [text "Hide List"],
+                div [] (List.map getWordPairView model.filterPairs)
+            ]
+        else 
+            div [][
+                button [onClick ToggleShowList] [text "Show List"]
+            ]
+    ]
+
+getWordPairView : (String, String) -> Html Msg
+getWordPairView (strA, strB) =
+    div [] [text strA, text " -> " ,text strB]

--- a/src/Joke.elm
+++ b/src/Joke.elm
@@ -1,12 +1,15 @@
 module Joke exposing (..)
 
 import Http
+import Regex
 import Json.Decode exposing (..)
+
 
 type alias Joke = 
   { avatarUrl : String
   , id : String
   , message : String
+  , wordCount : Int
   }
 
 totalCatImages : number
@@ -27,8 +30,17 @@ buildJoke : String -> String -> Joke
 buildJoke id joke =
   { avatarUrl = (imageFromMessage joke), 
     id = id,
-    message = joke
+    message = joke,
+    wordCount =  wordCount joke
   }
+
+wordCount : String -> Int
+wordCount message = 
+  let
+    wordMatchPattern = Maybe.withDefault Regex.never <| Regex.fromString "(\\w+)"
+  in
+    List.length (Regex.find wordMatchPattern message)
+
 
 jokeDecoder : Decoder (Joke)
 jokeDecoder = Json.Decode.map2 (buildJoke) (field "id" string) (field "joke" string)

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -63,12 +63,20 @@ renderJoke joke =
   ] [
     img (itemStyle ++ [src joke.avatarUrl, width 50, height 50]) [text(joke.avatarUrl)],
     div (itemStyle ++ [style "font-style" "italic"]) [text(joke.id)],
-    div (itemStyle ++ [style "font-weight" "bold"]) [text(joke.message)]
+    div (itemStyle ++ [style "font-weight" "bold"]) [text(joke.message)],
+    div (itemStyle ++ [style "font-style" "italic", style "float" "right"]) [ text("(" ++ (String.fromInt joke.wordCount) ++ " words)")]
   ]
 
 view : Model -> Html Msg
 view model =
-  div [] (List.map renderJoke model.jokes)
+  div [] [
+    div itemStyle [
+      div [style "display" "inline-block"] [text "future home of the filter stuff"],
+      div [style "float" "right", style "display" "inline-block"] [text "future home of the sort btn"]
+    ],
+    div [] (List.map renderJoke model.jokes)
+  ]
+  
 
 getPage : Cmd Msg
 getPage =

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -109,7 +109,7 @@ renderJoke joke =
 view : Model -> Html Msg
 view model =
   div [] [
-    div itemStyle [
+    div [style "margin" "1vw"] [
       div [style "display" "inline-block"] [Html.map FilterMsg (Filter.getView model.filter)],
       div [style "float" "right", style "display" "inline-block"] [
         button [ onClick SwapSort] [text (getSortButtonText model)]

--- a/tests/FilterTests.elm
+++ b/tests/FilterTests.elm
@@ -1,0 +1,41 @@
+module FilterTests exposing (..)
+
+import Expect exposing (Expectation)
+import Test exposing (..)
+import Filter exposing (..)
+
+suite : Test
+suite =
+    describe "The Filter module" 
+        [ describe "filterText" 
+            [ test "changes words in a string, when on" <|
+                \_ -> 
+                    let
+                        testModel = 
+                            {
+                                on = True,
+                                showList = False,
+                                filterPairs = [("test", "REPLACED"), ("potato", "yam")],
+                                newFrom = "",
+                                newTo = ""
+                            }
+                    in
+                        Expect.equal [
+                            (Filter.filterText testModel "this is a test")
+                            , (Filter.filterText testModel "this is a test potato") 
+                            ] ["this is a REPLACED", "this is a REPLACED yam"]
+                , test "does not change words when not on" <|
+                    \_ ->
+                        let
+                            testModel =
+                                {
+                                    on = False,
+                                    showList = False,
+                                    filterPairs = [("test", "REPLACED"), ("potato", "yam")],
+                                    newFrom = "",
+                                    newTo = ""
+                                }
+                        in
+                            Expect.equal (Filter.filterText testModel "this is a test") "this is a test"
+            ]
+        ]

--- a/tests/JokeTests.elm
+++ b/tests/JokeTests.elm
@@ -1,4 +1,4 @@
-module Example exposing (..)
+module JokeTests exposing (..)
 
 import Expect exposing (Expectation)
 import Test exposing (..)
@@ -16,5 +16,16 @@ suite =
             id2 = imageIdFromMessage (String.repeat 53 "x") -- mod 16 = 5
           in
             Expect.equal [2, 5] [id1, id2]
+      ]
+      ,describe "wordCount"
+      [ test "builds avatar id from message length" <|
+        \_ ->
+          let
+            count1 = wordCount (String.repeat 50 "x")
+            count2 = wordCount "sentence with four words"
+            count3 = wordCount "sentence with, four words"
+            count4 = wordCount "sentence with  : four words !"
+          in
+            Expect.equal [1, 4, 4, 4] [count1, count2, count3, count4]
       ]
     ]


### PR DESCRIPTION
This pull request adds the two core features:

- A user-editable "profanity" filter
- A word count for each joke, that can be used to sort the jokes loaded on the page

The word count functionality is an extension of the existing modules: the `Joke` model is updated with a word count member, and the `Main` module is extended to handle displaying that word count, as well as sorting based on the word count.

I chose to implement the filter as its own module, exposing a function that will apply the defined filters to any string passed in. This should make is reasonably easy to re-use this filter in other places, if needed.

A couple of test verify the functionality of the new word count code, and the filter code.
